### PR TITLE
Upgrade to Godot 4.4

### DIFF
--- a/GDTask/GDTask.csproj
+++ b/GDTask/GDTask.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <EnableDynamicLoading>true</EnableDynamicLoading>
     <LangVersion>13</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -16,7 +16,7 @@
     <PackageId>GDTask</PackageId>
     <PackageVersion>1.3.0</PackageVersion>
     <Authors>DE-YU, Atlinx, Yoshifumi Kawai / Cysharp</Authors>
-    <Description>Provides an efficient async/await integration to Godot 4.1+</Description>
+    <Description>Provides an efficient async/await integration to Godot 4.4+</Description>
     <PackageProjectUrl>https://www.nuget.org/packages/GDTask</PackageProjectUrl>
     <PackageIcon>Logo.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -40,7 +40,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GodotSharp" Version="4.1.0"/>
-    <PackageReference Include="Godot.SourceGenerators" Version="4.1.0"/>
+    <PackageReference Include="GodotSharp" Version="4.4.0" />
+    <PackageReference Include="Godot.SourceGenerators" Version="4.4.0" />
   </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Stars](https://img.shields.io/github/stars/Delsin-Yu/GDTask.Nuget?color=brightgreen)](https://github.com/Delsin-Yu/GDTask.Nuget/stargazers)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/Delsin-Yu/GDTask.Nuget/blob/main/LICENSE)
 
-- Ported and Tested in Godot 4.2 with .Net module.
+- Ported and Tested in Godot 4.4 with .Net module.
 - This is the Nuget Package version based on code from:
   - **[Atlinx's GDTask addon for Godot](https://github.com/Fractural/GDTask)**
   - **[Cysharp's UniTask library for Unity](https://github.com/Cysharp/UniTask)**


### PR DESCRIPTION
This will make sure all of the APIs are up-to-date (since Godot's API gets several breaking changes) and also removes the `net6.0` and `net7.0` targets which are no longer supported by Microsoft.