### PR TITLE
Replace `#if DEBUG` compiler pre-processor (fix #6)

### DIFF
--- a/GDTask/src/CompilerServices/AsyncGDTaskMethodBuilder.cs
+++ b/GDTask/src/CompilerServices/AsyncGDTaskMethodBuilder.cs
@@ -116,21 +116,16 @@ namespace GodotTask.CompilerServices
             // don't use boxed stateMachine.
         }
 
-#if DEBUG
         // Important for IDE debugger.
         private object debuggingId;
         private object ObjectIdForDebugger
         {
             get
             {
-                if (debuggingId == null)
-                {
-                    debuggingId = new object();
-                }
+                debuggingId ??= new object();
                 return debuggingId;
             }
         }
-#endif
     }
 
     [StructLayout(LayoutKind.Auto)]
@@ -247,21 +242,15 @@ namespace GodotTask.CompilerServices
             // don't use boxed stateMachine.
         }
 
-#if DEBUG
         // Important for IDE debugger.
         private object debuggingId;
         private object ObjectIdForDebugger
         {
             get
             {
-                if (debuggingId == null)
-                {
-                    debuggingId = new object();
-                }
+                debuggingId ??= new object();
                 return debuggingId;
             }
         }
-#endif
-
     }
 }

--- a/GDTask/src/CompilerServices/AsyncGDTaskMethodBuilder.cs
+++ b/GDTask/src/CompilerServices/AsyncGDTaskMethodBuilder.cs
@@ -115,17 +115,6 @@ namespace GodotTask.CompilerServices
         {
             // don't use boxed stateMachine.
         }
-
-        // Important for IDE debugger.
-        private object debuggingId;
-        private object ObjectIdForDebugger
-        {
-            get
-            {
-                debuggingId ??= new object();
-                return debuggingId;
-            }
-        }
     }
 
     [StructLayout(LayoutKind.Auto)]
@@ -240,17 +229,6 @@ namespace GodotTask.CompilerServices
         public void SetStateMachine(IAsyncStateMachine stateMachine)
         {
             // don't use boxed stateMachine.
-        }
-
-        // Important for IDE debugger.
-        private object debuggingId;
-        private object ObjectIdForDebugger
-        {
-            get
-            {
-                debuggingId ??= new object();
-                return debuggingId;
-            }
         }
     }
 }

--- a/GDTask/src/CompilerServices/AsyncGDTaskVoidMethodBuilder.cs
+++ b/GDTask/src/CompilerServices/AsyncGDTaskVoidMethodBuilder.cs
@@ -102,20 +102,15 @@ namespace GodotTask.CompilerServices
             // don't use boxed stateMachine.
         }
 
-#if DEBUG
         // Important for IDE debugger.
         private object debuggingId;
         private object ObjectIdForDebugger
         {
             get
             {
-                if (debuggingId == null)
-                {
-                    debuggingId = new object();
-                }
+                debuggingId ??= new object();
                 return debuggingId;
             }
         }
-#endif
     }
 }

--- a/GDTask/src/CompilerServices/AsyncGDTaskVoidMethodBuilder.cs
+++ b/GDTask/src/CompilerServices/AsyncGDTaskVoidMethodBuilder.cs
@@ -101,16 +101,5 @@ namespace GodotTask.CompilerServices
         {
             // don't use boxed stateMachine.
         }
-
-        // Important for IDE debugger.
-        private object debuggingId;
-        private object ObjectIdForDebugger
-        {
-            get
-            {
-                debuggingId ??= new object();
-                return debuggingId;
-            }
-        }
     }
 }

--- a/GDTask/src/GDTask.Delay.cs
+++ b/GDTask/src/GDTask.Delay.cs
@@ -170,10 +170,6 @@ namespace GodotTask
             // Force use Realtime in editor.
             if (GDTaskPlayerLoopRunner.IsMainThread && Engine.IsEditorHint())
             {
-                if (delayType != DelayType.Realtime)
-                {
-                    GD.Print("When running by the editor's main thread, delayType must be DelayType.Realtime!");
-                }
                 delayType = DelayType.Realtime;
             }
 

--- a/GDTask/src/GDTask.Delay.cs
+++ b/GDTask/src/GDTask.Delay.cs
@@ -167,8 +167,7 @@ namespace GodotTask
                 throw new ArgumentOutOfRangeException("Delay does not allow minus delayTimeSpan. delayTimeSpan:" + delayTimeSpan);
             }
 
-#if DEBUG
-            // force use Realtime.
+            // Force use Realtime in editor.
             if (GDTaskPlayerLoopRunner.IsMainThread && Engine.IsEditorHint())
             {
                 if (delayType != DelayType.Realtime)
@@ -177,7 +176,6 @@ namespace GodotTask
                 }
                 delayType = DelayType.Realtime;
             }
-#endif
 
             switch (delayType)
             {
@@ -472,22 +470,10 @@ namespace GodotTask
                         return false;
                     }
 
-                    // skip in initial frame.
+                    // Skip in initial frame.
                     if (isMainThread && initialFrame == Engine.GetProcessFrames())
                     {
-#if DEBUG
-                        // force use Realtime.
-                        if (GDTaskPlayerLoopRunner.IsMainThread && Engine.IsEditorHint())
-                        {
-                            //goto ++currentFrameCount
-                        }
-                        else
-                        {
-                            return true;
-                        }
-#else
                         return true;
-#endif
                     }
                 }
 

--- a/GDTask/src/Internal/ContinuationQueue.cs
+++ b/GDTask/src/Internal/ContinuationQueue.cs
@@ -82,29 +82,32 @@ namespace GodotTask.Internal
             return rest;
         }
 
-        // delegate entrypoint.
+        // Delegate entrypoint.
         public void Run()
         {
-            // for debugging, create named stacktrace.
-#if DEBUG
-            switch (timing)
+            // For debugging, create named stacktrace.
+            if (Engine.IsEditorHint())
             {
-                case PlayerLoopTiming.PhysicsProcess:
-                    PhysicsProcess();
-                    break;
-                case PlayerLoopTiming.Process:
-                    Process();
-                    break;
-                case PlayerLoopTiming.IsolatedProcess:
-                    IsolatedProcess();
-                    break;
-                case PlayerLoopTiming.IsolatedPhysicsProcess:
-                    IsolatedPhysicsProcess();
-                    break;
+                switch (timing)
+                {
+                    case PlayerLoopTiming.PhysicsProcess:
+                        PhysicsProcess();
+                        break;
+                    case PlayerLoopTiming.Process:
+                        Process();
+                        break;
+                    case PlayerLoopTiming.IsolatedProcess:
+                        IsolatedProcess();
+                        break;
+                    case PlayerLoopTiming.IsolatedPhysicsProcess:
+                        IsolatedPhysicsProcess();
+                        break;
+                }
             }
-#else
-            RunCore();
-#endif
+            else
+            {
+                RunCore();
+            }
         }
 
         private void PhysicsProcess() => RunCore();

--- a/GDTask/src/Internal/ContinuationQueue.cs
+++ b/GDTask/src/Internal/ContinuationQueue.cs
@@ -85,39 +85,6 @@ namespace GodotTask.Internal
         // Delegate entrypoint.
         public void Run()
         {
-            // For debugging, create named stacktrace.
-            if (Engine.IsEditorHint())
-            {
-                switch (timing)
-                {
-                    case PlayerLoopTiming.PhysicsProcess:
-                        PhysicsProcess();
-                        break;
-                    case PlayerLoopTiming.Process:
-                        Process();
-                        break;
-                    case PlayerLoopTiming.IsolatedProcess:
-                        IsolatedProcess();
-                        break;
-                    case PlayerLoopTiming.IsolatedPhysicsProcess:
-                        IsolatedPhysicsProcess();
-                        break;
-                }
-            }
-            else
-            {
-                RunCore();
-            }
-        }
-
-        private void PhysicsProcess() => RunCore();
-        private void Process() => RunCore();
-        private void IsolatedPhysicsProcess() => RunCore();
-        private void IsolatedProcess() => RunCore();
-
-        [System.Diagnostics.DebuggerHidden]
-        private void RunCore()
-        {
             {
                 bool lockTaken = false;
                 try

--- a/GDTask/src/Internal/PlayerLoopRunner.cs
+++ b/GDTask/src/Internal/PlayerLoopRunner.cs
@@ -72,39 +72,6 @@ namespace GodotTask.Internal
         // Delegate entrypoint.
         public void Run()
         {
-            // For debugging, create named stacktrace.
-            if (Engine.IsEditorHint())
-            {
-                switch (timing)
-                {
-                    case PlayerLoopTiming.PhysicsProcess:
-                        PhysicsProcess();
-                        break;
-                    case PlayerLoopTiming.Process:
-                        Process();
-                        break;
-                    case PlayerLoopTiming.IsolatedProcess:
-                        IsolatedProcess();
-                        break;
-                    case PlayerLoopTiming.IsolatedPhysicsProcess:
-                        IsolatedPhysicsProcess();
-                        break;
-                }
-            }
-            else
-            {
-                RunCore();
-            }
-        }
-
-        private void PhysicsProcess() => RunCore();
-        private void Process() => RunCore();
-        private void IsolatedPhysicsProcess() => RunCore();
-        private void IsolatedProcess() => RunCore();
-
-        [System.Diagnostics.DebuggerHidden]
-        private void RunCore()
-        {
             lock (runningAndQueueLock)
             {
                 running = true;

--- a/GDTask/src/Internal/PlayerLoopRunner.cs
+++ b/GDTask/src/Internal/PlayerLoopRunner.cs
@@ -69,29 +69,32 @@ namespace GodotTask.Internal
             }
         }
 
-        // delegate entrypoint.
+        // Delegate entrypoint.
         public void Run()
         {
-            // for debugging, create named stacktrace.
-#if DEBUG
-            switch (timing)
+            // For debugging, create named stacktrace.
+            if (Engine.IsEditorHint())
             {
-                case PlayerLoopTiming.PhysicsProcess:
-                    PhysicsProcess();
-                    break;
-                case PlayerLoopTiming.Process:
-                    Process();
-                    break;
-                case PlayerLoopTiming.IsolatedProcess:
-                    IsolatedProcess();
-                    break;
-                case PlayerLoopTiming.IsolatedPhysicsProcess:
-                    IsolatedPhysicsProcess();
-                    break;
+                switch (timing)
+                {
+                    case PlayerLoopTiming.PhysicsProcess:
+                        PhysicsProcess();
+                        break;
+                    case PlayerLoopTiming.Process:
+                        Process();
+                        break;
+                    case PlayerLoopTiming.IsolatedProcess:
+                        IsolatedProcess();
+                        break;
+                    case PlayerLoopTiming.IsolatedPhysicsProcess:
+                        IsolatedPhysicsProcess();
+                        break;
+                }
             }
-#else
-            RunCore();
-#endif
+            else
+            {
+                RunCore();
+            }
         }
 
         private void PhysicsProcess() => RunCore();

--- a/GDTask/src/PlayerLoopTimer.cs
+++ b/GDTask/src/PlayerLoopTimer.cs
@@ -28,13 +28,11 @@ namespace GodotTask
 
         public static PlayerLoopTimer Create(TimeSpan interval, bool periodic, DelayType delayType, PlayerLoopTiming playerLoopTiming, CancellationToken cancellationToken, Action<object> timerCallback, object state)
         {
-#if DEBUG
-            // force use Realtime.
+            // Force use Realtime.
             if (GDTaskPlayerLoopRunner.IsMainThread && Engine.IsEditorHint())
             {
                 delayType = DelayType.Realtime;
             }
-#endif
 
             switch (delayType)
             {


### PR DESCRIPTION
Fixes #6.

Also relevant is `OS.IsDebugBuild()`:
> Returns true if the Godot binary used to run the project is a debug export template, or when running in the editor.
> 
> Returns false if the Godot binary used to run the project is a release export template.
> 
> Note: To check whether the Godot binary used to run the project is an export template (debug or release), use OS.has_feature("template") instead.

Note: if the best possible performance is desired, it may be good to just scrap some of these, since they seem more useful for debugging `GDTask` itself (which is presumably done at the official `GDTask` repository).

Side note: A release for #8 would be nice. I'll try to add some tests as requested.