### PR TITLE
Implment Signal GDTask utility methods

### DIFF
--- a/GDTask.Tests/Constants.cs
+++ b/GDTask.Tests/Constants.cs
@@ -34,13 +34,15 @@ internal static class Constants
     internal static GDTask DelayRealtimeWithReturn(int multiplier = 1, CancellationToken? cancellationToken = default) => GDTask.Delay(DelayTimeSpan * multiplier, DelayType.Realtime, cancellationToken: cancellationToken ?? CancellationToken.None).ContinueWith(() => ReturnValue);
     internal static GDTask<int> DelayWithReturn(CancellationToken? cancellationToken = default) => GDTask.Delay(DelayTimeSpan, cancellationToken: cancellationToken ?? CancellationToken.None).ContinueWith(() => ReturnValue);
 
-    internal static Node CreateTestNode(string nodeName)
+    internal static TNode CreateTestNode<TNode>(string nodeName) where TNode : Node, new()
     {
-        var node = new Node { Name = nodeName };
+        var node = new TNode { Name = nodeName };
         var root = ((SceneTree)Engine.GetMainLoop()).Root;
         root.CallDeferred(Node.MethodName.AddChild, node);
         return node;
     }
+    
+    internal static Node CreateTestNode(string nodeName) => CreateTestNode<Node>(nodeName);
     
     internal static CancellationToken CreateCanceledToken() => new(true);
 }

--- a/GDTask.Tests/test/GDTaskTest_Extensions_SignalAwaiter.cs
+++ b/GDTask.Tests/test/GDTaskTest_Extensions_SignalAwaiter.cs
@@ -1,0 +1,54 @@
+﻿using System.Threading.Tasks;
+using GdUnit4;
+using Godot;
+
+namespace GodotTask.Tests;
+
+[TestSuite]
+public partial class GDTaskTest_SignalAwaiter
+{
+    [TestCase]
+    public static async Task SignalAwaiter_AsGDTask_0Arg()
+    {
+        await GDTask.SwitchToMainThread();
+        var node = Constants.CreateTestNode<SignalTestNode>("SignalTestNode");
+        
+        Constants.Delay()
+            .ContinueWith(node.EmitParam0)
+            .Forget();
+        
+        var result = await node.ToSignal(node, SignalTestNode.SignalName.Param0).AsGDTask();
+      
+        node.QueueFree();
+
+        Assertions.AssertThat(result.Length).IsEqual(0);
+    }
+
+    [TestCase]
+    public static async Task SignalAwaiter_AsGDTask_2Args()
+    {
+        await GDTask.SwitchToMainThread();
+        var node = Constants.CreateTestNode<SignalTestNode>("SignalTestNode");
+        
+        Constants.Delay()
+            .ContinueWith(() => node.EmitParam2(Constants.ReturnValue, Constants.ReturnValue))
+            .Forget();
+        
+        var (result1, result2) = await node.ToSignal(node, SignalTestNode.SignalName.Param2).AsGDTask<int, int>();
+        
+        node.QueueFree();
+
+        Assertions.AssertThat(result1).IsEqual(Constants.ReturnValue);
+        Assertions.AssertThat(result2).IsEqual(Constants.ReturnValue);
+    }
+
+    public partial class SignalTestNode : Node
+    {
+        [Signal] private delegate void Param0EventHandler();
+        [Signal] private delegate void Param2EventHandler(Variant param1, Variant param2);
+        
+        public void EmitParam0() => EmitSignalParam0();
+        public void EmitParam2(Variant param1, Variant param2) => EmitSignalParam2(param1, param2);
+    }
+    
+}

--- a/GDTask.Tests/test/GDTaskTest_Extensions_SignalAwaiter.cs.uid
+++ b/GDTask.Tests/test/GDTaskTest_Extensions_SignalAwaiter.cs.uid
@@ -1,0 +1,1 @@
+uid://bduwsbvy1i5hn

--- a/GDTask/src/GDTaskExtensions.Signal.cs
+++ b/GDTask/src/GDTaskExtensions.Signal.cs
@@ -1,0 +1,55 @@
+using System;
+using Godot;
+
+namespace GodotTask;
+
+public static partial class GDTaskExtensions
+{
+    /// <summary>
+    /// Create a <see cref="GDTask"/> that wraps around this <see cref="SignalAwaiter"/>.
+    /// </summary>
+    public static async GDTask<Variant[]> AsGDTask(this SignalAwaiter signalAwaiter)
+    {
+        return await signalAwaiter;
+    }
+    
+    /// <inhritdoc cref="AsGDTask(SignalAwaiter)"/>
+    public static async GDTask<T> AsGDTask<[MustBeVariant] T>(this SignalAwaiter signalAwaiter)
+    {
+        var result = await signalAwaiter;
+        if(result.Length < 1) throw new IndexOutOfRangeException("SignalAwaiter result is empty!");
+        return result[0].As<T>();
+    }
+    
+    /// <inhritdoc cref="AsGDTask(SignalAwaiter)"/>
+    public static async GDTask<(T1, T2)> AsGDTask<[MustBeVariant] T1, [MustBeVariant] T2>(this SignalAwaiter signalAwaiter)
+    {
+        var result = await signalAwaiter;
+        if(result.Length < 2) throw new IndexOutOfRangeException($"SignalAwaiter result is {result.Length}, which is less than 2!");
+        return (result[0].As<T1>(), result[1].As<T2>());
+    }
+    
+    /// <inhritdoc cref="AsGDTask(SignalAwaiter)"/>
+    public static async GDTask<(T1, T2, T3)> AsGDTask<[MustBeVariant] T1, [MustBeVariant] T2, [MustBeVariant] T3>(this SignalAwaiter signalAwaiter)
+    {
+        var result = await signalAwaiter;
+        if(result.Length < 3) throw new IndexOutOfRangeException($"SignalAwaiter result is {result.Length}, which is less than 3!");
+        return (result[0].As<T1>(), result[1].As<T2>(), result[2].As<T3>());
+    }
+    
+    /// <inhritdoc cref="AsGDTask(SignalAwaiter)"/>
+    public static async GDTask<(T1, T2, T3, T4)> AsGDTask<[MustBeVariant] T1, [MustBeVariant] T2, [MustBeVariant] T3, [MustBeVariant] T4>(this SignalAwaiter signalAwaiter)
+    {
+        var result = await signalAwaiter;
+        if(result.Length < 4) throw new IndexOutOfRangeException($"SignalAwaiter result is {result.Length}, which is less than 4!");
+        return (result[0].As<T1>(), result[1].As<T2>(), result[2].As<T3>(), result[3].As<T4>());
+    }
+    
+    /// <inhritdoc cref="AsGDTask(SignalAwaiter)"/>
+    public static async GDTask<(T1, T2, T3, T4, T5)> AsGDTask<[MustBeVariant] T1, [MustBeVariant] T2, [MustBeVariant] T3, [MustBeVariant] T4, [MustBeVariant] T5>(this SignalAwaiter signalAwaiter)
+    {
+        var result = await signalAwaiter;
+        if(result.Length < 5) throw new IndexOutOfRangeException($"SignalAwaiter result is {result.Length}, which is less than 5!");
+        return (result[0].As<T1>(), result[1].As<T2>(), result[2].As<T3>(), result[3].As<T4>(), result[4].As<T5>());
+    }
+}


### PR DESCRIPTION
This allows Godot Signal awaiters to be converted to GDTasks, which can be combined with other GDTask utility methods in various programming scenarios.

```csharp
var yesPressed = yesButton.ToSignal(yesButton, BaseButton.SignalName.Pressed).AsGDTask();
var noPressed = noButton.ToSignal(noButton, BaseButton.SignalName.Pressed).AsGDTask();

var (winArgumentIndex, _, _) = await GDTask.WhenAny(yesPressed, noPressed);

if (winArgumentIndex == 0) GD.Print("Yes button pressed");
else GD.Print("No button pressed");
```