### PR TITLE
Add generic `state` to `RunOnThreadPool`

### DIFF
--- a/GDTask/src/GDTask.Run.cs
+++ b/GDTask/src/GDTask.Run.cs
@@ -41,11 +41,12 @@ namespace GodotTask
         /// <summary>
         /// Queues the specified work to run on the ThreadPool and returns a <see cref="GDTask"/> handle for that work.
         /// </summary>
+        /// <typeparam name="TState">The type of the <paramref name="state"/> passed to <paramref name="action"/>.</typeparam>
         /// <param name="action">The work to execute asynchronously</param>
-        /// <param name="state">Object to which to pass to action (may be null)</param>
+        /// <param name="state">The value to pass to <paramref name="action"/></param>
         /// <param name="configureAwait">Returns to the main thread after await if set to true, otherwise, the executing thread is undefined</param>
         /// <param name="cancellationToken">A cancellation token that should be used to cancel the work</param>
-        public static async GDTask RunOnThreadPool(Action<object> action, object state, bool configureAwait = true, CancellationToken cancellationToken = default)
+        public static async GDTask RunOnThreadPool<TState>(Action<TState> action, TState state, bool configureAwait = true, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -71,6 +72,9 @@ namespace GodotTask
 
             cancellationToken.ThrowIfCancellationRequested();
         }
+        /// <inheritdoc cref="RunOnThreadPool{TState}(Action{TState}, TState, bool, CancellationToken)"/>
+        public static GDTask RunOnThreadPool(Action<object> action, object state, bool configureAwait = true, CancellationToken cancellationToken = default)
+            => RunOnThreadPool<object>(action, state, configureAwait, cancellationToken);
 
         /// <summary>
         /// Create and queues the specified task to run on the ThreadPool and returns a <see cref="GDTask"/> handle for that work.
@@ -108,11 +112,12 @@ namespace GodotTask
         /// <summary>
         /// Create and queues the specified task to run on the ThreadPool and returns a <see cref="GDTask"/> handle for that work.
         /// </summary>
+        /// <typeparam name="TState">The type of the <paramref name="state"/> passed to <paramref name="action"/>.</typeparam>
         /// <param name="action">The delegate which create the task</param>
-        /// <param name="state">Object to which to pass to action (may be null)</param>
+        /// <param name="state">The value to pass to <paramref name="action"/></param>
         /// <param name="configureAwait">Returns to the main thread after await if set to true, otherwise, the executing thread is undefined</param>
         /// <param name="cancellationToken">A cancellation token that should be used to cancel the work</param>
-        public static async GDTask RunOnThreadPool(Func<object, GDTask> action, object state, bool configureAwait = true, CancellationToken cancellationToken = default)
+        public static async GDTask RunOnThreadPool<TState>(Func<TState, GDTask> action, TState state, bool configureAwait = true, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -138,6 +143,9 @@ namespace GodotTask
 
             cancellationToken.ThrowIfCancellationRequested();
         }
+        /// <inheritdoc cref="RunOnThreadPool{TState}(Func{TState, GDTask}, TState, bool, CancellationToken)"/>
+        public static GDTask RunOnThreadPool(Func<object, GDTask> action, object state, bool configureAwait = true, CancellationToken cancellationToken = default)
+            => RunOnThreadPool<object>(action, state, configureAwait, cancellationToken);
 
         /// <summary>
         /// Queues the specified work to run on the ThreadPool and returns a <see cref="GDTask"/> handle for that work.
@@ -212,11 +220,12 @@ namespace GodotTask
         /// Create and queues the specified task to run on the ThreadPool and returns a <see cref="GDTask"/> handle for that work.
         /// </summary>
         /// <typeparam name="T">The type of the result returned by the task.</typeparam>
+        /// <typeparam name="TState">The type of the <paramref name="state"/> passed to <paramref name="func"/>.</typeparam>
         /// <param name="func">The work to execute asynchronously</param>
-        /// <param name="state">Object to which to pass to action (may be null)</param>
+        /// <param name="state">The value to pass to <paramref name="func"/></param>
         /// <param name="configureAwait">Returns to the main thread after await if set to true, otherwise, the executing thread is undefined</param>
         /// <param name="cancellationToken">A cancellation token that should be used to cancel the work</param>
-        public static async GDTask<T> RunOnThreadPool<T>(Func<object, T> func, object state, bool configureAwait = true, CancellationToken cancellationToken = default)
+        public static async GDTask<T> RunOnThreadPool<T, TState>(Func<TState, T> func, TState state, bool configureAwait = true, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -241,16 +250,20 @@ namespace GodotTask
                 return func(state);
             }
         }
+        /// <inheritdoc cref="RunOnThreadPool{T, TState}(Func{TState, T}, TState, bool, CancellationToken)"/>
+        public static GDTask<T> RunOnThreadPool<T>(Func<object, T> func, object state, bool configureAwait = true, CancellationToken cancellationToken = default)
+            => RunOnThreadPool<T, object>(func, state, configureAwait, cancellationToken);
 
         /// <summary>
         /// Create and queues the specified task to run on the ThreadPool and returns a <see cref="GDTask"/> handle for that work.
         /// </summary>
+        /// <typeparam name="TState">The type of the <paramref name="state"/> passed to <paramref name="func"/>.</typeparam>
         /// <typeparam name="T">The type of the result returned by the task.</typeparam>
         /// <param name="func">The delegate which create the task</param>
-        /// <param name="state">Object to which to pass to action (may be null)</param>
+        /// <param name="state">The value to pass to <paramref name="func"/></param>
         /// <param name="configureAwait">Returns to the main thread after await if set to true, otherwise, the executing thread is undefined</param>
         /// <param name="cancellationToken">A cancellation token that should be used to cancel the work</param>
-        public static async GDTask<T> RunOnThreadPool<T>(Func<object, GDTask<T>> func, object state, bool configureAwait = true, CancellationToken cancellationToken = default)
+        public static async GDTask<T> RunOnThreadPool<T, TState>(Func<TState, GDTask<T>> func, TState state, bool configureAwait = true, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -278,6 +291,9 @@ namespace GodotTask
                 return result;
             }
         }
+        /// <inheritdoc cref="RunOnThreadPool{T, TState}(Func{TState, T}, TState, bool, CancellationToken)"/>
+        public static GDTask<T> RunOnThreadPool<T>(Func<object, GDTask<T>> func, object state, bool configureAwait = true, CancellationToken cancellationToken = default)
+            => RunOnThreadPool<T, object>(func, state, configureAwait, cancellationToken);
     }
 }
 


### PR DESCRIPTION
Currently, `RunOnThreadPool` accepts an `object state` parameter which is passed to the given `action`. This can be used to use a static `action` without allocating a wrapper that passes the `state`. However, it only accepts `state` as `object`. This pull request makes `state` a generic type parameter, without making any breaking changes.

Benefits:
- No need to cast `object` parameter to `TState` parameter.
- Performance benefit if `action` does not accept `object`, since you don't have to create a wrapper that casts `object state` to `TState state` before passing to `action`.