### PR TITLE
GlobalCancellationToken improvements

### DIFF
--- a/GDTask/src/GDTask.Deferred.cs
+++ b/GDTask/src/GDTask.Deferred.cs
@@ -112,6 +112,7 @@ public partial struct GDTask
             TaskTracker.RemoveTracking(this);
             core.Reset();
             cancellationToken = default;
+            globalCancellationToken = default;
             return pool.TryPush(this);
         }
     }

--- a/GDTask/src/GDTask.Delay.cs
+++ b/GDTask/src/GDTask.Delay.cs
@@ -279,6 +279,7 @@ namespace GodotTask
                 TaskTracker.RemoveTracking(this);
                 core.Reset();
                 cancellationToken = default;
+                globalCancellationToken = default;
                 return pool.TryPush(this);
             }
         }
@@ -385,6 +386,7 @@ namespace GodotTask
                 TaskTracker.RemoveTracking(this);
                 core.Reset();
                 cancellationToken = default;
+                globalCancellationToken = default;
                 return pool.TryPush(this);
             }
         }
@@ -512,6 +514,7 @@ namespace GodotTask
                 currentFrameCount = default;
                 delayFrameCount = default;
                 cancellationToken = default;
+                globalCancellationToken = default;
                 return pool.TryPush(this);
             }
         }
@@ -638,6 +641,7 @@ namespace GodotTask
                 delayTimeSpan = default;
                 elapsed = default;
                 cancellationToken = default;
+                globalCancellationToken = default;
                 return pool.TryPush(this);
             }
         }
@@ -751,6 +755,7 @@ namespace GodotTask
                 core.Reset();
                 stopwatch = default;
                 cancellationToken = default;
+                globalCancellationToken = default;
                 return pool.TryPush(this);
             }
         }

--- a/GDTask/src/GDTask.WaitUntil.cs
+++ b/GDTask/src/GDTask.WaitUntil.cs
@@ -171,6 +171,7 @@ namespace GodotTask
                 core.Reset();
                 predicate = default;
                 cancellationToken = default;
+                globalCancellationToken = default;
                 return pool.TryPush(this);
             }
         }
@@ -286,6 +287,7 @@ namespace GodotTask
                 core.Reset();
                 predicate = default;
                 cancellationToken = default;
+                globalCancellationToken = default;
                 return pool.TryPush(this);
             }
         }
@@ -384,6 +386,7 @@ namespace GodotTask
                 TaskTracker.RemoveTracking(this);
                 core.Reset();
                 cancellationToken = default;
+                globalCancellationToken = default;
                 return pool.TryPush(this);
             }
         }
@@ -516,6 +519,7 @@ namespace GodotTask
                 monitorFunction = default;
                 equalityComparer = default;
                 cancellationToken = default;
+                globalCancellationToken = default;
                 return pool.TryPush(this);
             }
         }
@@ -646,6 +650,7 @@ namespace GodotTask
                 monitorFunction = default;
                 equalityComparer = default;
                 cancellationToken = default;
+                globalCancellationToken = default;
                 return pool.TryPush(this);
             }
         }


### PR DESCRIPTION
This pull request makes two changes, concerning the addition of the global CancellationToken from #15:
- Made `CancellationTokenAwaitable` use the global CancellationToken. This is used in `GDTask.WaitUntilCanceled`. Previously, I assumed it shouldn't be affected because it's already waiting for another cancellation token, but I decided that since the purpose of the global CancellationToken is to cancel everything, it should cancel this.
- Set the global cancellation token tokens to `default` in the `TryReturn` methods along with the cancellation tokens. This probably won't have any meaningful effect, but I figure it should be released along with the other resources.