### PR TITLE
Use `Lock` everywhere in .NET 9+

### DIFF
--- a/GDTask/src/AsyncLazy.cs
+++ b/GDTask/src/AsyncLazy.cs
@@ -35,14 +35,22 @@ namespace GodotTask
         private readonly GDTaskCompletionSource completionSource;
         private GDTask.Awaiter awaiter;
 
+#if NET9_0_OR_GREATER
+        private readonly Lock syncLock;
+#else
         private readonly object syncLock;
+#endif
         private bool initialized;
 
         public AsyncLazy(Func<GDTask> taskFactory)
         {
             this.taskFactory = taskFactory;
             completionSource = new GDTaskCompletionSource();
+#if NET9_0_OR_GREATER
+            syncLock = new Lock();
+#else
             syncLock = new object();
+#endif
             initialized = false;
         }
 
@@ -152,14 +160,22 @@ namespace GodotTask
         private readonly GDTaskCompletionSource<T> completionSource;
         private GDTask<T>.Awaiter awaiter;
 
+#if NET9_0_OR_GREATER
+        private readonly Lock syncLock;
+#else
         private readonly object syncLock;
+#endif
         private bool initialized;
 
         public AsyncLazy(Func<GDTask<T>> taskFactory)
         {
             this.taskFactory = taskFactory;
             completionSource = new GDTaskCompletionSource<T>();
+#if NET9_0_OR_GREATER
+            syncLock = new Lock();
+#else
             syncLock = new object();
+#endif
             initialized = false;
         }
 

--- a/GDTask/src/GDTaskObservableExtensions.cs
+++ b/GDTask/src/GDTaskObservableExtensions.cs
@@ -324,7 +324,11 @@ namespace GodotTask.Internal
 
     internal sealed class SingleAssignmentDisposable : IDisposable
     {
-        private readonly object gate = new object();
+#if NET9_0_OR_GREATER
+        private readonly Lock gate = new();
+#else
+        private readonly object gate = new();
+#endif
         private IDisposable current;
         private bool disposed;
 
@@ -379,7 +383,11 @@ namespace GodotTask.Internal
 
     internal sealed class AsyncSubject<T> : IObservable<T>, IObserver<T>
     {
-        private readonly object observerLock = new object();
+#if NET9_0_OR_GREATER
+        private readonly Lock observerLock = new();
+#else
+        private readonly object observerLock = new();
+#endif
 
         private T lastValue;
         private bool hasValue;
@@ -535,7 +543,11 @@ namespace GodotTask.Internal
 
         private class Subscription : IDisposable
         {
-            private readonly object gate = new object();
+#if NET9_0_OR_GREATER
+        private readonly Lock gate = new();
+#else
+        private readonly object gate = new();
+#endif
             private AsyncSubject<T> parent;
             private IObserver<T> unsubscribeTarget;
 

--- a/GDTask/src/Internal/PlayerLoopRunner.cs
+++ b/GDTask/src/Internal/PlayerLoopRunner.cs
@@ -1,6 +1,6 @@
-﻿
-using Godot;
+﻿using Godot;
 using System;
+using System.Threading;
 
 namespace GodotTask.Internal
 {
@@ -8,8 +8,13 @@ namespace GodotTask.Internal
     {
         private const int InitialSize = 16;
 
-        private readonly object runningAndQueueLock = new object();
-        private readonly object arrayLock = new object();
+#if NET9_0_OR_GREATER
+        private readonly Lock runningAndQueueLock = new();
+        private readonly Lock arrayLock = new();
+#else
+        private readonly object runningAndQueueLock = new();
+        private readonly object arrayLock = new();
+#endif
         private readonly Action<Exception> unhandledExceptionCallback= ex => GD.PrintErr(ex);
 
         private int tail = 0;


### PR DESCRIPTION
Updates to `System.Threading.Lock` in .NET 9+

Already doing this in some places but not others