### PR TITLE
Make global `CancellationToken` thread-safe

### DIFF
--- a/GDTask/src/GDTask.cs
+++ b/GDTask/src/GDTask.cs
@@ -98,7 +98,7 @@ namespace GodotTask
         /// Cancels all running <see cref="GDTask"/>s and throws <see cref="OperationCanceledException"/>s at their call sites;
         /// this is equivalent to passing a <see cref="CancellationToken"/> to each <see cref="GDTask"/> and performing a cancellation.
         /// </summary>
-        public static void CancelAllTasks() => GDTaskPlayerLoopRunner.CancelAllTasks();
+        public static void CancelAllTasks() => GDTaskPlayerLoopRunner.CancelGlobalCancellationTokenSource();
 
         /// <summary>
         /// Creates a <see cref="GDTask"/> allows to await multiple times.

--- a/GDTask/src/PlayerLoopRunner/GDTaskPlayerLoopRunner.cs
+++ b/GDTask/src/PlayerLoopRunner/GDTaskPlayerLoopRunner.cs
@@ -112,13 +112,13 @@ namespace GodotTask
         public double PhysicsDeltaTime => GetPhysicsProcessDeltaTime();
 
         private static GDTaskPlayerLoopRunner s_Global;
-        private static CancellationTokenSource globalCancellationTokenSource = new();
+        private static Tuple<CancellationTokenSource, CancellationToken> globalCancellationTuple = CreateCancellationTuple();
         private int mainThreadId;
         private ContinuationQueue[] yielders;
         private ContinuationQueue deferredYielder;
         private PlayerLoopRunner[] runners;
         private PlayerLoopRunner deferredRunner;
-        
+
         public override void _Ready()
         {
             if (s_Global == null)
@@ -190,15 +190,21 @@ namespace GodotTask
             deferredRunner.Run();
         }
 
-        public static void CancelAllTasks()
+        public static void CancelGlobalCancellationTokenSource()
         {
-            var oldGlobalCancellationTokenSource = Interlocked.Exchange(ref globalCancellationTokenSource, new CancellationTokenSource());
-            oldGlobalCancellationTokenSource.Cancel();
-            oldGlobalCancellationTokenSource.Dispose();
+            var oldGlobalCancellationTuple = Interlocked.Exchange(ref globalCancellationTuple, CreateCancellationTuple());
+            oldGlobalCancellationTuple.Item1.Cancel();
+            oldGlobalCancellationTuple.Item1.Dispose();
         }
         public static CancellationToken GetGlobalCancellationToken()
         {
-            return globalCancellationTokenSource.Token;
+            return globalCancellationTuple.Item2;
+        }
+        
+        private static Tuple<CancellationTokenSource, CancellationToken> CreateCancellationTuple()
+        {
+            CancellationTokenSource source = new();
+            return Tuple.Create(source, source.Token);
         }
     }
 }


### PR DESCRIPTION
I got a rare exception running the test using the global CancellationToken, and I found a potential thread-safety issue:

- Thread A runs `GetGlobalCancellationToken` and gets a `CancellationTokenSource` from the `globalCancellationTokenSource` field.
- Thread B runs `CancelAllTasks` and replaces the global `CancellationTokenSource`, cancelling/disposing the original global `CancellationTokenSource`.
- Thread A runs `.Token` on its now-disposed `CancellationTokenSource`, which throws an `ObjectDisposedException`.

This is only a problem because [`CancellationTokenSource.Token` throws if the source is disposed](https://github.com/dotnet/runtime/issues/105811).

The solution I came up with is to store a tuple including the global `CancellationTokenSource` and its `CancellationToken`. I used a reference `Tuple` instead of a `ValueTuple` because `Interlocked.Exchange` only works on reference types.

Unlike `CancellationTokenSource`, `CancellationToken`'s APIs continue to work even if the `CancellationTokenSource` is disposed. For example, `Register` eventually runs `if (_disposed) { return default; }`. The only API which isn't safe is `WaitHandle`, which we don't use and should not be used.

Let me know your thoughts!