### PR TITLE
Optimize `GDTask.WhenAll`

### DIFF
--- a/GDTask/src/GDTask.WhenAll.cs
+++ b/GDTask/src/GDTask.WhenAll.cs
@@ -52,6 +52,10 @@ namespace GodotTask
             {
                 return CompletedTask;
             }
+            if (tasks.Length == 1)
+            {
+                return tasks[0];
+            }
 
             return new GDTask(new WhenAllPromise(tasks), 0);
         }
@@ -63,6 +67,10 @@ namespace GodotTask
             {
                 return CompletedTask;
             }
+            if (tasks.Length == 1)
+            {
+                return tasks[0];
+            }
 
             return new GDTask(new WhenAllPromise(tasks), 0);
         }
@@ -71,6 +79,14 @@ namespace GodotTask
         public static GDTask WhenAll(IEnumerable<GDTask> tasks)
         {
             using var usage = EnumerableUtils.ToSpan(tasks, out var span);
+            if (span.Length == 0)
+            {
+                return CompletedTask;
+            }
+            if (span.Length == 1)
+            {
+                return span[0];
+            }
             var promise = new WhenAllPromise(span); // consumed array in constructor.
             return new GDTask(promise, 0);
         }


### PR DESCRIPTION
An optimization for `GDTask.WhenAll` when `tasks.Length == 1`.

This optimization is performed in [`Task.WhenAll`](https://github.com/dotnet/dotnet/blob/b0f34d51fccc69fd334253924abd8d6853fad7aa/src/runtime/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs#L6034).