### PR TITLE
Fix AttachExternalCancellation pooling

### DIFF
--- a/GDTask.Tests/Constants.cs
+++ b/GDTask.Tests/Constants.cs
@@ -36,9 +36,11 @@ internal static class Constants
 
     internal static GDTask DelayRealtime(int multiplier = 1, CancellationToken? cancellationToken = default) => GDTask.Delay(DelayTimeSpan * multiplier, DelayType.Realtime, cancellationToken: cancellationToken ?? CancellationToken.None);
     internal static GDTask Delay(CancellationToken? cancellationToken = default) => GDTask.Delay(DelayTimeSpan, cancellationToken: cancellationToken ?? CancellationToken.None);
+    internal static GDTask DelayHalf(CancellationToken? cancellationToken = default) => GDTask.Delay(DelayTimeSpan / 2, cancellationToken: cancellationToken ?? CancellationToken.None);
 
     internal static GDTask DelayRealtimeWithReturn(int multiplier = 1, CancellationToken? cancellationToken = default) => GDTask.Delay(DelayTimeSpan * multiplier, DelayType.Realtime, cancellationToken: cancellationToken ?? CancellationToken.None).ContinueWith(() => ReturnValue);
     internal static GDTask<int> DelayWithReturn(CancellationToken? cancellationToken = default) => GDTask.Delay(DelayTimeSpan, cancellationToken: cancellationToken ?? CancellationToken.None).ContinueWith(() => ReturnValue);
+    internal static GDTask<int> DelayHalfWithReturn(CancellationToken? cancellationToken = default) => GDTask.Delay(DelayTimeSpan / 2, cancellationToken: cancellationToken ?? CancellationToken.None).ContinueWith(() => ReturnValue);
 
     internal static TNode CreateTestNode<TNode>(string nodeName) where TNode : Node, new()
     {

--- a/GDTask.Tests/test/GDTaskTest_Utils.cs
+++ b/GDTask.Tests/test/GDTaskTest_Utils.cs
@@ -11,10 +11,15 @@ public class GDTaskTest_Utils
     [TestCase, RequireGodotRuntime]
     public static async Task GDTask_AttachExternalCancellation()
     {
+        using var neverCts = new CancellationTokenSource();
+        using var otherCts = new CancellationTokenSource();
+
         await Constants.WaitForTaskReadyAsync();
         try
         {
-            await Constants.Delay().AttachExternalCancellation(Constants.CreateCanceledToken());
+            await Constants.Delay().AttachExternalCancellation(neverCts.Token);
+            _ = Constants.DelayHalf().ContinueWith(otherCts.Cancel);
+            await Constants.Delay().AttachExternalCancellation(otherCts.Token);
         }
         catch (OperationCanceledException)
         {
@@ -27,10 +32,15 @@ public class GDTaskTest_Utils
     [TestCase, RequireGodotRuntime]
     public static async Task GDTaskT_AttachExternalCancellation()
     {
+        using var neverCts = new CancellationTokenSource();
+        using var otherCts = new CancellationTokenSource();
+
         await Constants.WaitForTaskReadyAsync();
         try
         {
-            await Constants.DelayWithReturn().AttachExternalCancellation(Constants.CreateCanceledToken());
+            await Constants.DelayWithReturn().AttachExternalCancellation(neverCts.Token);
+            _ = Constants.DelayHalfWithReturn().ContinueWith(otherCts.Cancel);
+            await Constants.DelayWithReturn().AttachExternalCancellation(otherCts.Token);
         }
         catch (OperationCanceledException)
         {

--- a/GDTask/src/GDTaskExtensions.cs
+++ b/GDTask/src/GDTaskExtensions.cs
@@ -278,6 +278,8 @@ namespace GodotTask
 
             private async GDTaskVoid RunTask(GDTask task)
             {
+                CancellationTokenRegistration currentTokenRegistration = tokenRegistration;
+
                 try
                 {
                     await task;
@@ -289,7 +291,7 @@ namespace GodotTask
                 }
                 finally
                 {
-                    tokenRegistration.Dispose();
+                    currentTokenRegistration.Dispose();
                 }
             }
 
@@ -307,7 +309,6 @@ namespace GodotTask
                 }
                 finally
                 {
-                    tokenRegistration.Dispose();
                     TryReturn();
                 }
             }
@@ -332,6 +333,7 @@ namespace GodotTask
                 TaskTracker.RemoveTracking(this);
                 core.Reset();
                 cancellationToken = default;
+                tokenRegistration.Dispose();
                 tokenRegistration = default;
                 return pool.TryPush(this);
             }
@@ -381,6 +383,8 @@ namespace GodotTask
 
             private async GDTaskVoid RunTask(GDTask<T> task)
             {
+                CancellationTokenRegistration currentTokenRegistration = tokenRegistration;
+
                 try
                 {
                     core.TrySetResult(await task);
@@ -391,7 +395,7 @@ namespace GodotTask
                 }
                 finally
                 {
-                    tokenRegistration.Dispose();
+                    currentTokenRegistration.Dispose();
                 }
             }
 
@@ -409,7 +413,6 @@ namespace GodotTask
                 }
                 finally
                 {
-                    tokenRegistration.Dispose();
                     TryReturn();
                 }
             }
@@ -422,7 +425,6 @@ namespace GodotTask
                 }
                 finally
                 {
-                    tokenRegistration.Dispose();
                     TryReturn();
                 }
             }
@@ -447,6 +449,7 @@ namespace GodotTask
                 TaskTracker.RemoveTracking(this);
                 core.Reset();
                 cancellationToken = default;
+                tokenRegistration.Dispose();
                 tokenRegistration = default;
                 return pool.TryPush(this);
             }


### PR DESCRIPTION
I have verified that the bugs in #36 were caused by pooling and that the bugs have been fixed here. (Fixes #36)

Essentially, this does three things:
1. Improves the tests to be affected by pooling.
2. Caches the token registration in a local variable to avoid disposing of the registration after it's returned to the pool.
3. Also disposes of the token registration before returning to the pool, just in case.

@Delsin-Yu You should also run the tests to ensure this is fixed for you as well :)