### PR TITLE
Add `ContinueWithVoid`

### DIFF
--- a/GDTask.Tests/test/GDTaskTest_Utils.cs
+++ b/GDTask.Tests/test/GDTaskTest_Utils.cs
@@ -469,6 +469,88 @@ public class GDTaskTest_Utils
     }
 
     [TestCase, RequireGodotRuntime]
+    public static async Task GDTask_ContinueWithVoid()
+    {
+        await Constants.WaitForTaskReadyAsync();
+        var result = false;
+        Constants.DelayHalf().ContinueWithVoid(() => result = true);
+        await Constants.Delay();
+        Assertions.AssertThat(result).IsTrue();
+    }
+
+    [TestCase, RequireGodotRuntime]
+    public static async Task GDTask_ContinueWithVoid_GDTaskVoid()
+    {
+        await Constants.WaitForTaskReadyAsync();
+        var result = false;
+        Constants.DelayHalf().ContinueWithVoid(async () =>
+        {
+            await GDTask.NextFrame();
+            result = true;
+        });
+        await Constants.Delay();
+        Assertions.AssertThat(result).IsTrue();
+    }
+
+    [TestCase, RequireGodotRuntime]
+    public static async Task GDTaskT_ContinueWithVoid_T()
+    {
+        await Constants.WaitForTaskReadyAsync();
+        var result = false;
+        Constants.DelayHalfWithReturn().ContinueWithVoid(value =>
+        {
+            if (value == Constants.ReturnValue)
+            {
+                result = true;
+            }
+        });
+        await Constants.Delay();
+        Assertions.AssertThat(result).IsTrue();
+    }
+
+    [TestCase, RequireGodotRuntime]
+    public static async Task GDTaskT_ContinueWithVoid()
+    {
+        await Constants.WaitForTaskReadyAsync();
+        var result = false;
+        Constants.DelayHalfWithReturn().ContinueWithVoid(() => result = true);
+        await Constants.Delay();
+        Assertions.AssertThat(result).IsTrue();
+    }
+
+    [TestCase, RequireGodotRuntime]
+    public static async Task GDTaskT_ContinueWithVoid_T_GDTaskVoid()
+    {
+        await Constants.WaitForTaskReadyAsync();
+        var result = false;
+        Constants.DelayHalfWithReturn().ContinueWithVoid(async value =>
+        {
+            await GDTask.NextFrame();
+            if (value == Constants.ReturnValue)
+            {
+                await GDTask.NextFrame();
+                result = true;
+            }
+        });
+        await Constants.Delay();
+        Assertions.AssertThat(result).IsTrue();
+    }
+
+    [TestCase, RequireGodotRuntime]
+    public static async Task GDTaskT_ContinueWithVoid_GDTaskVoid()
+    {
+        await Constants.WaitForTaskReadyAsync();
+        var result = false;
+        Constants.DelayHalfWithReturn().ContinueWithVoid(async () =>
+        {
+            await GDTask.NextFrame();
+            result = true;
+        });
+        await Constants.Delay();
+        Assertions.AssertThat(result).IsTrue();
+    }
+
+    [TestCase, RequireGodotRuntime]
     public static async Task GDTask_Unwrap_GDTask_GDTask()
     {
         await Constants.WaitForTaskReadyAsync();

--- a/GDTask/src/GDTaskExtensions.cs
+++ b/GDTask/src/GDTaskExtensions.cs
@@ -292,6 +292,54 @@ public static partial class GDTaskExtensions
             await task;
             return await continuationFunction();
         }
+
+        /// <summary>
+        /// Creates a lightweight continuation that executes when the target <see cref="GDTask" /> completes and does not have an awaitable completion.
+        /// </summary>
+        public void ContinueWithVoid(Action<T> continuationFunction)
+        {
+            static async GDTaskVoid ContinueWithGDTaskVoid(GDTask<T> task, Action<T> continuationFunction)
+            {
+                continuationFunction(await task);
+            }
+
+            ContinueWithGDTaskVoid(task, continuationFunction).Forget();
+        }
+
+        /// <inheritdoc cref="ContinueWithVoid{T}(GDTask{T}, Action{T})" />
+        public void ContinueWithVoid(Action continuationFunction)
+        {
+            static async GDTaskVoid ContinueWithGDTaskVoid(GDTask<T> task, Action continuationFunction)
+            {
+                await task;
+                continuationFunction();
+            }
+
+            ContinueWithGDTaskVoid(task, continuationFunction).Forget();
+        }
+
+        /// <inheritdoc cref="ContinueWithVoid{T}(GDTask{T}, Action{T})" />
+        public void ContinueWithVoid(Func<T, GDTaskVoid> continuationFunction)
+        {
+            static async GDTaskVoid ContinueWithGDTaskVoid(GDTask<T> task, Func<T, GDTaskVoid> continuationFunction)
+            {
+                continuationFunction(await task).Forget();
+            }
+
+            ContinueWithGDTaskVoid(task, continuationFunction).Forget();
+        }
+
+        /// <inheritdoc cref="ContinueWithVoid{T}(GDTask{T}, Action{T})" />
+        public void ContinueWithVoid(Func<GDTaskVoid> continuationFunction)
+        {
+            static async GDTaskVoid ContinueWithGDTaskVoid(GDTask<T> task, Func<GDTaskVoid> continuationFunction)
+            {
+                await task;
+                continuationFunction().Forget();
+            }
+
+            ContinueWithGDTaskVoid(task, continuationFunction).Forget();
+        }
     }
 
     /// <param name="task">The <see cref="GDTask" /> to associate the time out to</param>
@@ -539,6 +587,30 @@ public static partial class GDTaskExtensions
         {
             await task;
             return await continuationFunction();
+        }
+
+        /// <inheritdoc cref="ContinueWithVoid{T}(GDTask{T}, Action{T})" />
+        public void ContinueWithVoid(Action continuationFunction)
+        {
+            static async GDTaskVoid ContinueWithGDTaskVoid(GDTask task, Action continuationFunction)
+            {
+                await task;
+                continuationFunction();
+            }
+
+            ContinueWithGDTaskVoid(task, continuationFunction).Forget();
+        }
+
+        /// <inheritdoc cref="ContinueWithVoid{T}(GDTask{T}, Action{T})" />
+        public void ContinueWithVoid(Func<GDTaskVoid> continuationFunction)
+        {
+            static async GDTaskVoid ContinueWithGDTaskVoid(GDTask task, Func<GDTaskVoid> continuationFunction)
+            {
+                await task;
+                continuationFunction().Forget();
+            }
+
+            ContinueWithGDTaskVoid(task, continuationFunction).Forget();
         }
     }
 

--- a/GDTask/src/GDTaskExtensions.cs
+++ b/GDTask/src/GDTaskExtensions.cs
@@ -139,7 +139,7 @@ public static partial class GDTaskExtensions
         /// <inheritdoc cref="Timeout(GDTask, TimeSpan, DelayType, PlayerLoopTiming, CancellationTokenSource)" />
         public async GDTask<T> Timeout(TimeSpan timeout, DelayType delayType = DelayType.DeltaTime, PlayerLoopTiming timeoutCheckTiming = PlayerLoopTiming.Process, CancellationTokenSource taskCancellationTokenSource = null) => await task.Timeout(timeout, delayType, GDTaskScheduler.GetPlayerLoop(timeoutCheckTiming), taskCancellationTokenSource);
 
-        /// <inheritdoc cref="Timeout(GDTask,System.TimeSpan,DelayType,IPlayerLoop,System.Threading.CancellationTokenSource)" />
+        /// <inheritdoc cref="Timeout(GDTask, TimeSpan, DelayType, IPlayerLoop, CancellationTokenSource)" />
         public async GDTask<T> Timeout(TimeSpan timeout, DelayType delayType, IPlayerLoop timeoutCheckLoop, CancellationTokenSource taskCancellationTokenSource = null)
         {
             Error.ThrowArgumentNullException(timeoutCheckLoop, nameof(timeoutCheckLoop));
@@ -180,8 +180,7 @@ public static partial class GDTaskExtensions
         /// <inheritdoc cref="TimeoutWithoutException(GDTask, TimeSpan, DelayType, PlayerLoopTiming, CancellationTokenSource)" />
         public async GDTask<(bool IsTimeout, T Result)> TimeoutWithoutException(TimeSpan timeout, DelayType delayType = DelayType.DeltaTime, PlayerLoopTiming timeoutCheckTiming = PlayerLoopTiming.Process, CancellationTokenSource taskCancellationTokenSource = null) => await task.TimeoutWithoutException(timeout, delayType, GDTaskScheduler.GetPlayerLoop(timeoutCheckTiming), taskCancellationTokenSource);
 
-        /// <inheritdoc
-        ///     cref="TimeoutWithoutException(GDTask,System.TimeSpan,DelayType,IPlayerLoop,System.Threading.CancellationTokenSource)" />
+        /// <inheritdoc cref="TimeoutWithoutException(GDTask, TimeSpan, DelayType, IPlayerLoop, CancellationTokenSource)" />
         public async GDTask<(bool IsTimeout, T Result)> TimeoutWithoutException(TimeSpan timeout, DelayType delayType, IPlayerLoop timeoutCheckLoop, CancellationTokenSource taskCancellationTokenSource = null)
         {
             Error.ThrowArgumentNullException(timeoutCheckLoop, nameof(timeoutCheckLoop));
@@ -257,37 +256,37 @@ public static partial class GDTaskExtensions
         /// </summary>
         public async GDTask ContinueWith(Action<T> continuationFunction) => continuationFunction(await task);
 
-        /// <inheritdoc cref="GDTaskExtensions.ContinueWith{T}(GodotTask.GDTask{T},System.Action{T})" />
+        /// <inheritdoc cref="ContinueWith{T}(GDTask{T}, Action{T})" />
         public async GDTask ContinueWith(Func<T, GDTask> continuationFunction) => await continuationFunction(await task);
 
-        /// <inheritdoc cref="GDTaskExtensions.ContinueWith{T}(GodotTask.GDTask{T},System.Action{T})" />
+        /// <inheritdoc cref="ContinueWith{T}(GDTask{T}, Action{T})" />
         public async GDTask<TReturn> ContinueWith<TReturn>(Func<T, TReturn> continuationFunction) => continuationFunction(await task);
 
-        /// <inheritdoc cref="GDTaskExtensions.ContinueWith{T}(GodotTask.GDTask{T},System.Action{T})" />
+        /// <inheritdoc cref="ContinueWith{T}(GDTask{T}, Action{T})" />
         public async GDTask<TReturn> ContinueWith<TReturn>(Func<T, GDTask<TReturn>> continuationFunction) => await continuationFunction(await task);
 
-        /// <inheritdoc cref="GDTaskExtensions.ContinueWith{T}(GodotTask.GDTask{T},System.Action{T})" />
+        /// <inheritdoc cref="ContinueWith{T}(GDTask{T}, Action{T})" />
         public async GDTask ContinueWith(Action continuationFunction)
         {
             await task;
             continuationFunction();
         }
 
-        /// <inheritdoc cref="GDTaskExtensions.ContinueWith{T}(GodotTask.GDTask{T},System.Action{T})" />
+        /// <inheritdoc cref="ContinueWith{T}(GDTask{T}, Action{T})" />
         public async GDTask ContinueWith(Func<GDTask> continuationFunction)
         {
             await task;
             await continuationFunction();
         }
 
-        /// <inheritdoc cref="GDTaskExtensions.ContinueWith{T}(GodotTask.GDTask{T},System.Action{T})" />
+        /// <inheritdoc cref="ContinueWith{T}(GDTask{T}, Action{T})" />
         public async GDTask<TR> ContinueWith<TR>(Func<TR> continuationFunction)
         {
             await task;
             return continuationFunction();
         }
 
-        /// <inheritdoc cref="GDTaskExtensions.ContinueWith{T}(GodotTask.GDTask{T},System.Action{T})" />
+        /// <inheritdoc cref="ContinueWith{T}(GDTask{T}, Action{T})" />
         public async GDTask<TR> ContinueWith<TR>(Func<GDTask<TR>> continuationFunction)
         {
             await task;
@@ -514,28 +513,28 @@ public static partial class GDTaskExtensions
             else ForgetCoreWithCatch(task, exceptionHandler, handleExceptionOnMainThread).Forget();
         }
 
-        /// <inheritdoc cref="GDTaskExtensions.ContinueWith{T}(GodotTask.GDTask{T},System.Action{T})" />
+        /// <inheritdoc cref="ContinueWith{T}(GDTask{T}, Action{T})" />
         public async GDTask ContinueWith(Action continuationFunction)
         {
             await task;
             continuationFunction();
         }
 
-        /// <inheritdoc cref="GDTaskExtensions.ContinueWith{T}(GodotTask.GDTask{T},System.Action{T})" />
+        /// <inheritdoc cref="ContinueWith{T}(GDTask{T}, Action{T})" />
         public async GDTask ContinueWith(Func<GDTask> continuationFunction)
         {
             await task;
             await continuationFunction();
         }
 
-        /// <inheritdoc cref="GDTaskExtensions.ContinueWith{T}(GodotTask.GDTask{T},System.Action{T})" />
+        /// <inheritdoc cref="ContinueWith{T}(GDTask{T}, Action{T})" />
         public async GDTask<T> ContinueWith<T>(Func<T> continuationFunction)
         {
             await task;
             return continuationFunction();
         }
 
-        /// <inheritdoc cref="GDTaskExtensions.ContinueWith{T}(GodotTask.GDTask{T},System.Action{T})" />
+        /// <inheritdoc cref="ContinueWith{T}(GDTask{T}, Action{T})" />
         public async GDTask<T> ContinueWith<T>(Func<GDTask<T>> continuationFunction)
         {
             await task;

--- a/GDTask/src/GDTaskExtensions.cs
+++ b/GDTask/src/GDTaskExtensions.cs
@@ -139,7 +139,7 @@ public static partial class GDTaskExtensions
         /// <inheritdoc cref="Timeout(GDTask, TimeSpan, DelayType, PlayerLoopTiming, CancellationTokenSource)" />
         public async GDTask<T> Timeout(TimeSpan timeout, DelayType delayType = DelayType.DeltaTime, PlayerLoopTiming timeoutCheckTiming = PlayerLoopTiming.Process, CancellationTokenSource taskCancellationTokenSource = null) => await task.Timeout(timeout, delayType, GDTaskScheduler.GetPlayerLoop(timeoutCheckTiming), taskCancellationTokenSource);
 
-        /// <inheritdoc cref="Timeout(GDTask, TimeSpan, DelayType, IPlayerLoop, CancellationTokenSource)" />
+        /// <inheritdoc cref="Timeout(GDTask,System.TimeSpan,DelayType,IPlayerLoop,System.Threading.CancellationTokenSource)" />
         public async GDTask<T> Timeout(TimeSpan timeout, DelayType delayType, IPlayerLoop timeoutCheckLoop, CancellationTokenSource taskCancellationTokenSource = null)
         {
             Error.ThrowArgumentNullException(timeoutCheckLoop, nameof(timeoutCheckLoop));
@@ -180,7 +180,8 @@ public static partial class GDTaskExtensions
         /// <inheritdoc cref="TimeoutWithoutException(GDTask, TimeSpan, DelayType, PlayerLoopTiming, CancellationTokenSource)" />
         public async GDTask<(bool IsTimeout, T Result)> TimeoutWithoutException(TimeSpan timeout, DelayType delayType = DelayType.DeltaTime, PlayerLoopTiming timeoutCheckTiming = PlayerLoopTiming.Process, CancellationTokenSource taskCancellationTokenSource = null) => await task.TimeoutWithoutException(timeout, delayType, GDTaskScheduler.GetPlayerLoop(timeoutCheckTiming), taskCancellationTokenSource);
 
-        /// <inheritdoc cref="TimeoutWithoutException(GDTask, TimeSpan, DelayType, IPlayerLoop, CancellationTokenSource)" />
+        /// <inheritdoc
+        ///     cref="TimeoutWithoutException(GDTask,System.TimeSpan,DelayType,IPlayerLoop,System.Threading.CancellationTokenSource)" />
         public async GDTask<(bool IsTimeout, T Result)> TimeoutWithoutException(TimeSpan timeout, DelayType delayType, IPlayerLoop timeoutCheckLoop, CancellationTokenSource taskCancellationTokenSource = null)
         {
             Error.ThrowArgumentNullException(timeoutCheckLoop, nameof(timeoutCheckLoop));
@@ -256,37 +257,37 @@ public static partial class GDTaskExtensions
         /// </summary>
         public async GDTask ContinueWith(Action<T> continuationFunction) => continuationFunction(await task);
 
-        /// <inheritdoc cref="ContinueWith{T}(GDTask{T}, Action{T})" />
+        /// <inheritdoc cref="GDTaskExtensions.ContinueWith{T}(GodotTask.GDTask{T},System.Action{T})" />
         public async GDTask ContinueWith(Func<T, GDTask> continuationFunction) => await continuationFunction(await task);
 
-        /// <inheritdoc cref="ContinueWith{T}(GDTask{T}, Action{T})" />
+        /// <inheritdoc cref="GDTaskExtensions.ContinueWith{T}(GodotTask.GDTask{T},System.Action{T})" />
         public async GDTask<TReturn> ContinueWith<TReturn>(Func<T, TReturn> continuationFunction) => continuationFunction(await task);
 
-        /// <inheritdoc cref="ContinueWith{T}(GDTask{T}, Action{T})" />
+        /// <inheritdoc cref="GDTaskExtensions.ContinueWith{T}(GodotTask.GDTask{T},System.Action{T})" />
         public async GDTask<TReturn> ContinueWith<TReturn>(Func<T, GDTask<TReturn>> continuationFunction) => await continuationFunction(await task);
 
-        /// <inheritdoc cref="ContinueWith{T}(GDTask{T}, Action{T})" />
+        /// <inheritdoc cref="GDTaskExtensions.ContinueWith{T}(GodotTask.GDTask{T},System.Action{T})" />
         public async GDTask ContinueWith(Action continuationFunction)
         {
             await task;
             continuationFunction();
         }
 
-        /// <inheritdoc cref="ContinueWith{T}(GDTask{T}, Action{T})" />
+        /// <inheritdoc cref="GDTaskExtensions.ContinueWith{T}(GodotTask.GDTask{T},System.Action{T})" />
         public async GDTask ContinueWith(Func<GDTask> continuationFunction)
         {
             await task;
             await continuationFunction();
         }
 
-        /// <inheritdoc cref="ContinueWith{T}(GDTask{T}, Action{T})" />
+        /// <inheritdoc cref="GDTaskExtensions.ContinueWith{T}(GodotTask.GDTask{T},System.Action{T})" />
         public async GDTask<TR> ContinueWith<TR>(Func<TR> continuationFunction)
         {
             await task;
             return continuationFunction();
         }
 
-        /// <inheritdoc cref="ContinueWith{T}(GDTask{T}, Action{T})" />
+        /// <inheritdoc cref="GDTaskExtensions.ContinueWith{T}(GodotTask.GDTask{T},System.Action{T})" />
         public async GDTask<TR> ContinueWith<TR>(Func<GDTask<TR>> continuationFunction)
         {
             await task;
@@ -561,28 +562,28 @@ public static partial class GDTaskExtensions
             else ForgetCoreWithCatch(task, exceptionHandler, handleExceptionOnMainThread).Forget();
         }
 
-        /// <inheritdoc cref="ContinueWith{T}(GDTask{T}, Action{T})" />
+        /// <inheritdoc cref="GDTaskExtensions.ContinueWith{T}(GodotTask.GDTask{T},System.Action{T})" />
         public async GDTask ContinueWith(Action continuationFunction)
         {
             await task;
             continuationFunction();
         }
 
-        /// <inheritdoc cref="ContinueWith{T}(GDTask{T}, Action{T})" />
+        /// <inheritdoc cref="GDTaskExtensions.ContinueWith{T}(GodotTask.GDTask{T},System.Action{T})" />
         public async GDTask ContinueWith(Func<GDTask> continuationFunction)
         {
             await task;
             await continuationFunction();
         }
 
-        /// <inheritdoc cref="ContinueWith{T}(GDTask{T}, Action{T})" />
+        /// <inheritdoc cref="GDTaskExtensions.ContinueWith{T}(GodotTask.GDTask{T},System.Action{T})" />
         public async GDTask<T> ContinueWith<T>(Func<T> continuationFunction)
         {
             await task;
             return continuationFunction();
         }
 
-        /// <inheritdoc cref="ContinueWith{T}(GDTask{T}, Action{T})" />
+        /// <inheritdoc cref="GDTaskExtensions.ContinueWith{T}(GodotTask.GDTask{T},System.Action{T})" />
         public async GDTask<T> ContinueWith<T>(Func<GDTask<T>> continuationFunction)
         {
             await task;


### PR DESCRIPTION
Adds:
- `void GDTask.ContinueWithVoid(Action)`
- `void GDTask.ContinueWithVoid(Func<GDTaskVoid>)`
- `void GDTask<T>.ContinueWithVoid(Action<T>)`
- `void GDTask<T>.ContinueWithVoid(Action)`
- `void GDTask<T>.ContinueWithVoid(Func<T, GDTaskVoid>)`
- `void GDTask<T>.ContinueWithVoid(Func<GDTaskVoid>)`

Usage:
```cs
// Before:
GDTask.Delay(TimeSpan.FromSeconds(1.0)).ContinueWith(() => {
    Godot.GD.Print("Hi!");
}).Forget();

// Now:
GDTask.Delay(TimeSpan.FromSeconds(1.0)).ContinueWithVoid(() => {
    Godot.GD.Print("Hi!");
});
```

Closes #51.