### PR TITLE
Simplify doc comments

### DIFF
--- a/GDTask/src/GDTaskExtensions.Signal.cs
+++ b/GDTask/src/GDTaskExtensions.Signal.cs
@@ -23,7 +23,7 @@ partial struct GDTask
         return await tcs.Task;
     }
 
-    /// <inheritdoc cref="FromSignal(Godot.GodotObject,Godot.StringName,System.Threading.CancellationToken)" />
+    /// <inheritdoc cref="FromSignal(GodotObject, StringName, CancellationToken)" />
     public static async GDTask<T> FromSignal<[MustBeVariant] T>(GodotObject signalOwner, StringName signalName, CancellationToken cancellationToken)
     {
         var tcs = new GDTaskCompletionSource<T>();
@@ -38,7 +38,7 @@ partial struct GDTask
         return await tcs.Task;
     }
 
-    /// <inheritdoc cref="FromSignal(Godot.GodotObject,Godot.StringName,System.Threading.CancellationToken)" />
+    /// <inheritdoc cref="FromSignal(GodotObject, StringName, CancellationToken)" />
     public static async GDTask<(T1, T2)> FromSignal<[MustBeVariant] T1, [MustBeVariant] T2>(GodotObject signalOwner, StringName signalName, CancellationToken cancellationToken)
     {
         var tcs = new GDTaskCompletionSource<(T1, T2)>();
@@ -53,7 +53,7 @@ partial struct GDTask
         return await tcs.Task;
     }
 
-    /// <inheritdoc cref="FromSignal(Godot.GodotObject,Godot.StringName,System.Threading.CancellationToken)" />
+    /// <inheritdoc cref="FromSignal(GodotObject, StringName, CancellationToken)" />
     public static async GDTask<(T1, T2, T3)> FromSignal<[MustBeVariant] T1, [MustBeVariant] T2, [MustBeVariant] T3>(GodotObject signalOwner, StringName signalName, CancellationToken cancellationToken)
     {
         var tcs = new GDTaskCompletionSource<(T1, T2, T3)>();
@@ -68,7 +68,7 @@ partial struct GDTask
         return await tcs.Task;
     }
 
-    /// <inheritdoc cref="FromSignal(Godot.GodotObject,Godot.StringName,System.Threading.CancellationToken)" />
+    /// <inheritdoc cref="FromSignal(GodotObject, StringName, CancellationToken)" />
     public static async GDTask<(T1, T2, T3, T4)> FromSignal<[MustBeVariant] T1, [MustBeVariant] T2, [MustBeVariant] T3, [MustBeVariant] T4>(GodotObject signalOwner, StringName signalName, CancellationToken cancellationToken)
     {
         var tcs = new GDTaskCompletionSource<(T1, T2, T3, T4)>();
@@ -83,7 +83,7 @@ partial struct GDTask
         return await tcs.Task;
     }
 
-    /// <inheritdoc cref="FromSignal(Godot.GodotObject,Godot.StringName,System.Threading.CancellationToken)" />
+    /// <inheritdoc cref="FromSignal(GodotObject, StringName, CancellationToken)" />
     public static async GDTask<(T1, T2, T3, T4, T5)> FromSignal<[MustBeVariant] T1, [MustBeVariant] T2, [MustBeVariant] T3, [MustBeVariant] T4, [MustBeVariant] T5>(GodotObject signalOwner, StringName signalName, CancellationToken cancellationToken)
     {
         var tcs = new GDTaskCompletionSource<(T1, T2, T3, T4, T5)>();
@@ -98,27 +98,27 @@ partial struct GDTask
         return await tcs.Task;
     }
 
-    /// <inheritdoc cref="FromSignal(Godot.GodotObject,Godot.StringName,System.Threading.CancellationToken)" />
+    /// <inheritdoc cref="FromSignal(GodotObject, StringName, CancellationToken)" />
     public static GDTask<Variant[]> FromSignal(GodotObject signalOwner, StringName signalName) =>
         signalOwner.ToSignal(signalOwner, signalName).AsGDTask();
 
-    /// <inheritdoc cref="FromSignal(Godot.GodotObject,Godot.StringName,System.Threading.CancellationToken)" />
+    /// <inheritdoc cref="FromSignal(GodotObject, StringName, CancellationToken)" />
     public static GDTask<T> FromSignal<[MustBeVariant] T>(GodotObject signalOwner, StringName signalName) =>
         signalOwner.ToSignal(signalOwner, signalName).AsGDTask<T>();
 
-    /// <inheritdoc cref="FromSignal(Godot.GodotObject,Godot.StringName,System.Threading.CancellationToken)" />
+    /// <inheritdoc cref="FromSignal(GodotObject, StringName, CancellationToken)" />
     public static GDTask<(T1, T2)> FromSignal<[MustBeVariant] T1, [MustBeVariant] T2>(GodotObject signalOwner, StringName signalName) =>
         signalOwner.ToSignal(signalOwner, signalName).AsGDTask<T1, T2>();
 
-    /// <inheritdoc cref="FromSignal(Godot.GodotObject,Godot.StringName,System.Threading.CancellationToken)" />
+    /// <inheritdoc cref="FromSignal(GodotObject, StringName, CancellationToken)" />
     public static GDTask<(T1, T2, T3)> FromSignal<[MustBeVariant] T1, [MustBeVariant] T2, [MustBeVariant] T3>(GodotObject signalOwner, StringName signalName) =>
         signalOwner.ToSignal(signalOwner, signalName).AsGDTask<T1, T2, T3>();
 
-    /// <inheritdoc cref="FromSignal(Godot.GodotObject,Godot.StringName,System.Threading.CancellationToken)" />
+    /// <inheritdoc cref="FromSignal(GodotObject, StringName, CancellationToken)" />
     public static GDTask<(T1, T2, T3, T4)> FromSignal<[MustBeVariant] T1, [MustBeVariant] T2, [MustBeVariant] T3, [MustBeVariant] T4>(GodotObject signalOwner, StringName signalName) =>
         signalOwner.ToSignal(signalOwner, signalName).AsGDTask<T1, T2, T3, T4>();
 
-    /// <inheritdoc cref="FromSignal(Godot.GodotObject,Godot.StringName,System.Threading.CancellationToken)" />
+    /// <inheritdoc cref="FromSignal(GodotObject, StringName, CancellationToken)" />
     public static GDTask<(T1, T2, T3, T4, T5)> FromSignal<[MustBeVariant] T1, [MustBeVariant] T2, [MustBeVariant] T3, [MustBeVariant] T4, [MustBeVariant] T5>(GodotObject signalOwner, StringName signalName) =>
         signalOwner.ToSignal(signalOwner, signalName).AsGDTask<T1, T2, T3, T4, T5>();
 }

--- a/GDTask/src/GDTaskExtensions.cs
+++ b/GDTask/src/GDTaskExtensions.cs
@@ -139,7 +139,7 @@ public static partial class GDTaskExtensions
         /// <inheritdoc cref="Timeout(GDTask, TimeSpan, DelayType, PlayerLoopTiming, CancellationTokenSource)" />
         public async GDTask<T> Timeout(TimeSpan timeout, DelayType delayType = DelayType.DeltaTime, PlayerLoopTiming timeoutCheckTiming = PlayerLoopTiming.Process, CancellationTokenSource taskCancellationTokenSource = null) => await task.Timeout(timeout, delayType, GDTaskScheduler.GetPlayerLoop(timeoutCheckTiming), taskCancellationTokenSource);
 
-        /// <inheritdoc cref="Timeout(GDTask,System.TimeSpan,DelayType,IPlayerLoop,System.Threading.CancellationTokenSource)" />
+        /// <inheritdoc cref="Timeout(GDTask, TimeSpan, DelayType, IPlayerLoop, CancellationTokenSource)" />
         public async GDTask<T> Timeout(TimeSpan timeout, DelayType delayType, IPlayerLoop timeoutCheckLoop, CancellationTokenSource taskCancellationTokenSource = null)
         {
             Error.ThrowArgumentNullException(timeoutCheckLoop, nameof(timeoutCheckLoop));
@@ -180,8 +180,7 @@ public static partial class GDTaskExtensions
         /// <inheritdoc cref="TimeoutWithoutException(GDTask, TimeSpan, DelayType, PlayerLoopTiming, CancellationTokenSource)" />
         public async GDTask<(bool IsTimeout, T Result)> TimeoutWithoutException(TimeSpan timeout, DelayType delayType = DelayType.DeltaTime, PlayerLoopTiming timeoutCheckTiming = PlayerLoopTiming.Process, CancellationTokenSource taskCancellationTokenSource = null) => await task.TimeoutWithoutException(timeout, delayType, GDTaskScheduler.GetPlayerLoop(timeoutCheckTiming), taskCancellationTokenSource);
 
-        /// <inheritdoc
-        ///     cref="TimeoutWithoutException(GDTask,System.TimeSpan,DelayType,IPlayerLoop,System.Threading.CancellationTokenSource)" />
+        /// <inheritdoc cref="TimeoutWithoutException(GDTask, TimeSpan, DelayType, IPlayerLoop, CancellationTokenSource)" />
         public async GDTask<(bool IsTimeout, T Result)> TimeoutWithoutException(TimeSpan timeout, DelayType delayType, IPlayerLoop timeoutCheckLoop, CancellationTokenSource taskCancellationTokenSource = null)
         {
             Error.ThrowArgumentNullException(timeoutCheckLoop, nameof(timeoutCheckLoop));
@@ -257,37 +256,37 @@ public static partial class GDTaskExtensions
         /// </summary>
         public async GDTask ContinueWith(Action<T> continuationFunction) => continuationFunction(await task);
 
-        /// <inheritdoc cref="GDTaskExtensions.ContinueWith{T}(GodotTask.GDTask{T},System.Action{T})" />
+        /// <inheritdoc cref="ContinueWith{T}(GDTask{T}, Action{T})" />
         public async GDTask ContinueWith(Func<T, GDTask> continuationFunction) => await continuationFunction(await task);
 
-        /// <inheritdoc cref="GDTaskExtensions.ContinueWith{T}(GodotTask.GDTask{T},System.Action{T})" />
+        /// <inheritdoc cref="ContinueWith{T}(GDTask{T}, Action{T})" />
         public async GDTask<TReturn> ContinueWith<TReturn>(Func<T, TReturn> continuationFunction) => continuationFunction(await task);
 
-        /// <inheritdoc cref="GDTaskExtensions.ContinueWith{T}(GodotTask.GDTask{T},System.Action{T})" />
+        /// <inheritdoc cref="ContinueWith{T}(GDTask{T}, Action{T})" />
         public async GDTask<TReturn> ContinueWith<TReturn>(Func<T, GDTask<TReturn>> continuationFunction) => await continuationFunction(await task);
 
-        /// <inheritdoc cref="GDTaskExtensions.ContinueWith{T}(GodotTask.GDTask{T},System.Action{T})" />
+        /// <inheritdoc cref="ContinueWith{T}(GDTask{T}, Action{T})" />
         public async GDTask ContinueWith(Action continuationFunction)
         {
             await task;
             continuationFunction();
         }
 
-        /// <inheritdoc cref="GDTaskExtensions.ContinueWith{T}(GodotTask.GDTask{T},System.Action{T})" />
+        /// <inheritdoc cref="ContinueWith{T}(GDTask{T}, Action{T})" />
         public async GDTask ContinueWith(Func<GDTask> continuationFunction)
         {
             await task;
             await continuationFunction();
         }
 
-        /// <inheritdoc cref="GDTaskExtensions.ContinueWith{T}(GodotTask.GDTask{T},System.Action{T})" />
+        /// <inheritdoc cref="ContinueWith{T}(GDTask{T}, Action{T})" />
         public async GDTask<TR> ContinueWith<TR>(Func<TR> continuationFunction)
         {
             await task;
             return continuationFunction();
         }
 
-        /// <inheritdoc cref="GDTaskExtensions.ContinueWith{T}(GodotTask.GDTask{T},System.Action{T})" />
+        /// <inheritdoc cref="ContinueWith{T}(GDTask{T}, Action{T})" />
         public async GDTask<TR> ContinueWith<TR>(Func<GDTask<TR>> continuationFunction)
         {
             await task;
@@ -514,28 +513,28 @@ public static partial class GDTaskExtensions
             else ForgetCoreWithCatch(task, exceptionHandler, handleExceptionOnMainThread).Forget();
         }
 
-        /// <inheritdoc cref="GDTaskExtensions.ContinueWith{T}(GodotTask.GDTask{T},System.Action{T})" />
+        /// <inheritdoc cref="ContinueWith{T}(GDTask{T}, Action{T})" />
         public async GDTask ContinueWith(Action continuationFunction)
         {
             await task;
             continuationFunction();
         }
 
-        /// <inheritdoc cref="GDTaskExtensions.ContinueWith{T}(GodotTask.GDTask{T},System.Action{T})" />
+        /// <inheritdoc cref="ContinueWith{T}(GDTask{T}, Action{T})" />
         public async GDTask ContinueWith(Func<GDTask> continuationFunction)
         {
             await task;
             await continuationFunction();
         }
 
-        /// <inheritdoc cref="GDTaskExtensions.ContinueWith{T}(GodotTask.GDTask{T},System.Action{T})" />
+        /// <inheritdoc cref="ContinueWith{T}(GDTask{T}, Action{T})" />
         public async GDTask<T> ContinueWith<T>(Func<T> continuationFunction)
         {
             await task;
             return continuationFunction();
         }
 
-        /// <inheritdoc cref="GDTaskExtensions.ContinueWith{T}(GodotTask.GDTask{T},System.Action{T})" />
+        /// <inheritdoc cref="ContinueWith{T}(GDTask{T}, Action{T})" />
         public async GDTask<T> ContinueWith<T>(Func<GDTask<T>> continuationFunction)
         {
             await task;


### PR DESCRIPTION
I did check several `.editorconfig` templates, but there doesn't seem to be an automated way to do this.

I did a search & replace for `cref="`, and fortunately, there don't seem to be that many doc comments in need of simplification. I'm fairly confident this is all of them.