### PR TITLE
Fix unnecessary newlines

### DIFF
--- a/GDTask.Tests/test/GDTaskTest_Core.cs
+++ b/GDTask.Tests/test/GDTaskTest_Core.cs
@@ -107,7 +107,6 @@ public class GDTaskTest_Core
         await GDTask.WaitUntil(() => completed);
     }
 
-
     [TestCase, RequireGodotRuntime]
     public static async Task GDTaskT_SuppressCancellationThrow()
     {

--- a/GDTask.Tests/test/GDTaskTest_Deferred.cs
+++ b/GDTask.Tests/test/GDTaskTest_Deferred.cs
@@ -52,6 +52,4 @@ public class GDTaskTest_Deferred
         
         throw new TestFailedException("Deferred Instructions not canceled");
     }
-
-
 }

--- a/GDTask.Tests/test/GDTaskTest_Delay.cs
+++ b/GDTask.Tests/test/GDTaskTest_Delay.cs
@@ -11,8 +11,6 @@ namespace GodotTask.Tests;
 [TestSuite]
 public class GDTaskTest_Delay
 {
-
-
     [TestCase, RequireGodotRuntime]
     public static async Task GDTask_Yield_Process()
     {

--- a/GDTask.Tests/test/GDTaskTest_Factory.cs
+++ b/GDTask.Tests/test/GDTaskTest_Factory.cs
@@ -294,7 +294,6 @@ public partial class GDTaskTest_Factory
         }
     }
 
-
     [TestCase, RequireGodotRuntime]
     public static async Task GDTask_Action_Token()
     {

--- a/GDTask.Tests/test/GDTaskTest_Threading.cs
+++ b/GDTask.Tests/test/GDTaskTest_Threading.cs
@@ -241,7 +241,6 @@ public class GDTaskTest_Threading
         }
     }
 
-
     [TestCase, RequireGodotRuntime]
     public static async Task GDTask_RunOnThreadPool_DelegateT()
     {
@@ -325,7 +324,6 @@ public class GDTaskTest_Threading
         }
     }
 
-
     [TestCase, RequireGodotRuntime]
     public static async Task GDTask_RunOnThreadPool_GDTask()
     {
@@ -402,7 +400,6 @@ public class GDTaskTest_Threading
         {
         }
     }
-
 
     [TestCase, RequireGodotRuntime]
     public static async Task GDTask_RunOnThreadPool_GDTaskT()
@@ -542,7 +539,6 @@ public class GDTaskTest_Threading
         Assertions
             .AssertThat(context == SynchronizationContext.Current);
     }
-
 
     [TestCase, RequireGodotRuntime]
     public static async Task GDTask_ReturnToMainThread_Token()

--- a/GDTask.Tests/test/GDTaskTest_Utils.cs
+++ b/GDTask.Tests/test/GDTaskTest_Utils.cs
@@ -78,7 +78,6 @@ public class GDTaskTest_Utils
         }
     }
 
-
     [TestCase, RequireGodotRuntime]
     public static async Task GDTask_AttachExternalCancellation_CancelTokenAfterUse()
     {

--- a/GDTask/src/AsyncLazy.cs
+++ b/GDTask/src/AsyncLazy.cs
@@ -80,7 +80,6 @@ class AsyncLazy : IAsyncLazy
         }
     }
 
-
     public GDTask.Awaiter GetAwaiter() => Task.GetAwaiter();
 
     private void EnsureInitialized()
@@ -187,7 +186,6 @@ class AsyncLazy<T> : IAsyncLazy<T>
             return _completionSource.Task;
         }
     }
-
 
     public GDTask<T>.Awaiter GetAwaiter() => Task.GetAwaiter();
 

--- a/GDTask/src/GDTask.Factory.cs
+++ b/GDTask/src/GDTask.Factory.cs
@@ -51,7 +51,6 @@ public partial struct GDTask
     /// <returns>The successfully completed task.</returns>
     public static GDTask<T> FromResult<T>(T value) => new(value);
 
-
     /// <summary>
     /// Creates a <see cref="GDTask" /> that has completed due to cancellation with the specified cancellation token.
     /// </summary>

--- a/GDTask/src/GDTask.WhenAll.cs
+++ b/GDTask/src/GDTask.WhenAll.cs
@@ -212,7 +212,6 @@ public partial struct GDTask
         return new(new WhenAllPromise<T>(tasks), 0);
     }
 
-
     /// <inheritdoc cref="WhenAll{T}(GDTask{T}[])" />
     public static GDTask<T[]> WhenAll<T>(IEnumerable<GDTask<T>> tasks)
     {

--- a/GDTask/src/GDTask.WhenAny.cs
+++ b/GDTask/src/GDTask.WhenAny.cs
@@ -201,7 +201,6 @@ public partial struct GDTask
         }
     }
 
-
     private sealed class WhenAnyPromise<T> : IGDTaskSource<(int, T)>
     {
         private int _completedCount;

--- a/GDTask/src/GDTaskCompletionSource.cs
+++ b/GDTask/src/GDTaskCompletionSource.cs
@@ -288,7 +288,6 @@ class AutoResetGDTaskCompletionSource : IGDTaskSource, ITaskPoolNode<AutoResetGD
     {
         try { _core.GetResult(token); }
         finally { TryReturn(); }
-
     }
 
     [DebuggerHidden]

--- a/GDTask/src/GDTaskObservableExtensions.cs
+++ b/GDTask/src/GDTaskObservableExtensions.cs
@@ -310,7 +310,6 @@ namespace GodotTask.Internal
             }
         }
 
-
         public void Dispose()
         {
             IDisposable old = null;

--- a/GDTask/src/Internal/PlayerLoopRunner.cs
+++ b/GDTask/src/Internal/PlayerLoopRunner.cs
@@ -127,7 +127,6 @@ sealed class PlayerLoopRunner
                 NEXT_LOOP: ;
             }
 
-
             lock (_runningAndQueueLock)
             {
                 _running = false;

--- a/GDTask/src/Internal/TypePrinter.cs
+++ b/GDTask/src/Internal/TypePrinter.cs
@@ -81,7 +81,6 @@ class TypePrinter
             // append brackets
             AppendArrayRecursive(sb, type);
 
-
             static void AppendArrayRecursive(StringBuilder sb, Type type)
             {
                 while (true)
@@ -148,7 +147,6 @@ class TypePrinter
                 sb.Append(')');
                 return;
             }
-
 
             //normal generic
             var typeName = type.Name.AsSpan();

--- a/README.md
+++ b/README.md
@@ -186,7 +186,6 @@ This package adds support for attaching a global cancellation token to GDTasks w
 
 Package: [GDTask.GlobalCancellation on NuGet](https://www.nuget.org/packages/GDTask.GlobalCancellation)
 
-
 Install:
 
 ```bash


### PR DESCRIPTION
Removes all unnecessary newlines in the project, identified with `(\r?\n){3}` regex (excluding the `.Generated` files).